### PR TITLE
Fix nextcloud syncing

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -84,6 +84,7 @@ int main(int argc, char* argv[]) {
                 if (username.size() != 0) {
                     c->set_basic_auth(username, password);
                 }
+                c->set_nextcloud(nextcloud);
                 clients.push_back(make_pair(buf, c));
             }
         }

--- a/source/webdav.cpp
+++ b/source/webdav.cpp
@@ -244,9 +244,9 @@ const char* gen_prop(string prefix, string command) {
 
 /// Read the timestamp from WebDAV server
 optional<vector<FileEntry>> WebDavClient::get_remote_files() {
-    string prefix = "d:";
+    string prefix = "D:";
     if (this->nextcloud) {
-        prefix = "D:";
+        prefix = "d:";
     }
 
     // Use PROPFIND to fetch file metadata

--- a/source/webdav.cpp
+++ b/source/webdav.cpp
@@ -297,7 +297,7 @@ optional<vector<FileEntry>> WebDavClient::get_remote_files() {
                     char* decoded = curl_easy_unescape(this->curl, text, 0, NULL);
                     path = string(decoded);
                 } else {
-                    printf("malformed WebDAV response: missing d:href in PROPFIND\n");
+                    printf("malformed WebDAV response: missing %s:href in PROPFIND\n", prefix.c_str());
                     return nullopt;
                 }
                 if (e->FirstChildElement(gen_prop(prefix, "propstat"))) {


### PR DESCRIPTION
Fixes https://github.com/szclsya/3DavSync/issues/2

3 things happening here:

1. `WebDavClient->set_nextcloud` is never called, so NC servers don't receive the NC query. NC servers would probably have worked with the RFC query, but..
2. Prefixes are flipped, NC should use `d:` namespace instead of `D:`, the reverse is happening.
3. Logging hardcodes the prefix to `d:`, so the fact that the wrong prefix is being used is obscured.

I suspect anyone with a working build is actually using binaries built from 0b3ef33c68459cbd64a17c16f6592f019554538f.